### PR TITLE
Improve font-locking of first line

### DIFF
--- a/git-commit.el
+++ b/git-commit.el
@@ -255,7 +255,7 @@ default comments in git commit messages"
       (2 'git-commit-comment-file-face))
      ("^#.*$"
       (0 'git-commit-comment-face))
-     ("\\`\\(.\\{,50\\}\\)\\(.*?\\)\n\\(.*\\)$"
+     ("\\`\\(?:\\(?:[[:space:]]*\\|#.*\\)\n\\)*\\(.\\{,50\\}\\)\\(.*?\\)\\(?:\n\\(.*\\)\\)?$"
       (1 'git-commit-summary-face)
       (2 'git-commit-overlong-summary-face)
       (3 'git-commit-nonempty-second-line-face))


### PR DESCRIPTION
- Allow whitespace and comments before the first line
- Font-lock the first line even if there is no second line
