### PR TITLE
Add more file names to auto-mode-alist

### DIFF
--- a/git-commit.el
+++ b/git-commit.el
@@ -572,8 +572,12 @@ Turning on git commit calls the hooks in `git-commit-mode-hook'."
   (add-to-list 'session-mode-disable-list 'git-commit-mode))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist
-             '("COMMIT_EDITMSG" . git-commit-mode))
+(setq auto-mode-alist
+      (append auto-mode-alist
+              '(("COMMIT_EDITMSG" . git-commit-mode)
+                ("NOTES_EDITMSG" . git-commit-mode)
+                ("MERGE_MSG" . git-commit-mode)
+                ("TAG_EDITMSG" . git-commit-mode))))
 
 (provide 'git-commit)
 


### PR DESCRIPTION
Besides editing commit messages, git-commit-mode can also be used to
edit merge, notes, and tag messages.
