### PR TITLE
Add missing require of cl

### DIFF
--- a/git-commit.el
+++ b/git-commit.el
@@ -20,6 +20,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl))
+
 (defgroup git-commit '((jit-lock custom-group))
   "Mode for editing git commit messages"
   :group 'faces)


### PR DESCRIPTION
Without this require, the right macro definitions are not pulled in when byte-compiling from command-line.
