### PR TITLE
Add highlighting to body lines that exceed 72 characters

### DIFF
--- a/git-commit.el
+++ b/git-commit.el
@@ -20,6 +20,8 @@
 
 ;;; Code:
 
+(require 'cl-lib)
+
 (defgroup git-commit '((jit-lock custom-group))
   "Mode for editing git commit messages"
   :group 'faces)
@@ -236,7 +238,7 @@ default comments in git commit messages"
    '(("^\\(#\s+On branch \\)\\(.*\\)$"
       (1 'git-commit-comment-face)
       (2 'git-commit-branch-face)))
-   (loop for exp in
+   (cl-loop for exp in
          '(("Not currently on any branch." . git-commit-no-branch-face)
            ("Changes to be committed:"     . git-commit-comment-heading-face)
            ("Untracked files:"             . git-commit-comment-heading-face)
@@ -329,7 +331,7 @@ configuration key KEY."
   "Get the value of the first defined environment variable.
 Walk VARS, call `getenv' on each element and return the first
 non-nil return value of `getenv'."
-  (loop for var in vars
+  (cl-loop for var in vars
         do (let ((val (getenv var)))
              (when val (return val)))))
 

--- a/git-commit.el
+++ b/git-commit.el
@@ -78,6 +78,20 @@
   "Face used to highlight text on the second line of git commit messages"
   :group 'git-commit-faces)
 
+(defface git-commit-overlong-body-face
+  '((((class color) (min-colors 88) (background light))
+     (:foreground "Red1" :weight bold))
+    (((class color) (min-colors 88) (background dark))
+     (:foreground "Pink" :weight bold))
+    (((class color) (min-colors 16) (background light))
+     (:foreground "Red1" :weight bold))
+    (((class color) (min-colors 16) (background dark))
+     (:foreground "Pink" :weight bold))
+    (((class color) (min-colors 8)) (:foreground "red"))
+    (t (:inverse-video t :weight bold)))
+  "Face used to highlight overlong parts of git commit message bodies"
+  :group 'git-commit-faces)
+
 (defface git-commit-text-face
   '((t (:inherit default)))
   "Face used to highlight text in git commit messages"
@@ -273,6 +287,9 @@ default comments in git commit messages"
       (2 'git-commit-note-address-face)
       (3 'git-commit-note-face)
       (4 'git-commit-note-brace-face))
+     ("\\(.\\{,72\\}\\)\\(.*?\\)?$"
+      (1 'git-commit-text-face)
+      (2 'git-commit-overlong-body-face))
      (".*"
       (0 'git-commit-text-face)))))
 


### PR DESCRIPTION
A _de facto_ standard for authoring good commit messages is to wrap the body to 72 characters (80-columns minus the width of one 8-character tab). This PR extends the mode to apply error highlights to lines which break the 72-character mark:

<img src="https://cloud.githubusercontent.com/assets/2346707/15303164/bbd5d0fa-1bf9-11e6-892e-329103e7e3a3.png" width="542" alt="Figure 1" />

The pattern-matching for the subject line remains unaffected:

<img src="https://cloud.githubusercontent.com/assets/2346707/15303224/f95ad5d8-1bf9-11e6-916b-49e7cb1afc57.png" width="542" alt="Figure 2" />
